### PR TITLE
issue #3 - gracefully ignore when git remote does not exist

### DIFF
--- a/lib/Dist/Zilla/PluginBundle/Milla.pm
+++ b/lib/Dist/Zilla/PluginBundle/Milla.pm
@@ -92,7 +92,7 @@ sub configure {
             allow_dirty_match => '\.pm$', # .pm files copied back from Release
         } ],
         [ 'Git::Tag', { tag_format => '%v', tag_message => '' } ],
-        [ 'Git::Push' ],
+        [ 'Git::Push', { remotes_must_exist => 0 } ],
 
     );
 }


### PR DESCRIPTION
Will this satisfy issue #3?  From Dist::Zilla::Plugin::Git::Push: 

> remotes_must_exist - if true, then Git::Push checks before a release to ensure that all named remotes specified in push_to are configured in your repo. The default is true. Remotes specified as a URL or path are not checked, but will produce a Will push to %s (not checked) message.

here's my output from testing:

```
[@Milla/NameFromDirectory] guessing your distribution name is git-test
[DZ] beginning to build git-test
[DZ] guessing dist's main_module is lib/git/test.pm
[@Milla/LicenseFromModule] guessing from lib/git/test.pm, License is Software::License::Perl_5
[@Milla/LicenseFromModule] Copyright 2013- Curtis Brandt <curtis@cpan.org>
[@Milla/VersionFromModule] dist version 0.02 (from lib/git/test.pm)
Next release version?  [0.03]:
[@Milla/ReversionOnRelease] Bumping $VERSION in lib/git/test.pm to 0.03
[@Milla/ExtraTests] rewriting release test xt/release/pod-syntax.t
[@Milla/Prereqs::FromCPANfile] Parsing 'cpanfile' to extract prereqs
[DZ] extracting distribution abstract from lib/git/test.pm
[@Milla/GithubMeta] A remote named 'origin' was specified, but does not appear to exist.
[@Milla/GithubMeta] skipping meta.resources.repository creation
[@Milla/Prereqs::FromCPANfile] Parsing 'cpanfile' to extract prereqs
[@Milla/ReadmeAnyFromPod] Override README.md in root
[DZ] writing git-test in git-test-0.03
[@Milla/CopyFilesFromBuild] Copied git-test-0.03/META.json to ./META.json
[@Milla/CopyFilesFromBuild] Copied git-test-0.03/Build.PL to ./Build.PL
[DZ] building archive with Archive::Tar; install Archive::Tar::Wrapper for improved speed
[DZ] writing archive to git-test-0.03.tar.gz
[@Milla/Git::Check] branch master is in a clean state
[@Milla/CheckChangesHasContent] Checking Changes
[@Milla/CheckChangesHasContent] Changes OK
[@Milla/TestRelease] Extracting /Users/curtisbrandt/Projects/git-test/git-test-0.03.tar.gz to .build/mOQ6IOsC5t
Creating new 'Build' script for 'git-test' version '0.03'
cp lib/git/test.pm blib/lib/git/test.pm
t/basic.t ............... ok
t/release-pod-syntax.t .. ok
All tests successful.
Files=2, Tests=2,  1 wallclock secs ( 0.02 usr  0.01 sys +  0.06 cusr  0.00 csys =  0.09 CPU)
Result: PASS
[@Milla/TestRelease] all's well; removing .build/mOQ6IOsC5t
*** Preparing to release git-test-0.03.tar.gz with @Milla/FakeRelease ***

Do you want to continue the release process? [Y/n]: Y
[@Milla/FakeRelease] Fake release happening (nothing was really done)
[@Milla/CopyFilesFromRelease] Copied git-test-0.03/lib/git/test.pm to lib/git/test.pm
[@Milla/Git::Commit] Committed Changes lib/git/test.pm META.json
[@Milla/Git::Tag] Tagged 0.03
[@Milla/Git::Push] pushing to origin
fatal: 'origin' does not appear to be a git repository
fatal: Could not read from remote repository.
```

Seems like everything released OK.  There is a 'fatal' warning at the end from Git::Push, but I don't think that interfered with the release process.

What do you think?
