### PR TITLE
Add role PluginRemover

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -55,6 +55,7 @@ my %module_build_args = (
     "Dist::Zilla::Plugin::VersionFromModule" => 0,
     "Dist::Zilla::PluginBundle::Git" => 0,
     "Dist::Zilla::Role::PluginBundle::Config::Slicer" => 0,
+    "Dist::Zilla::Role::PluginBundle::PluginRemover" => 0,
     "Module::CPANfile" => "0.9025",
     "perl" => "5.008005"
   },

--- a/META.json
+++ b/META.json
@@ -73,6 +73,7 @@
             "Dist::Zilla::Plugin::VersionFromModule" : "0",
             "Dist::Zilla::PluginBundle::Git" : "0",
             "Dist::Zilla::Role::PluginBundle::Config::Slicer" : "0",
+            "Dist::Zilla::Role::PluginBundle::PluginRemover" : "0",
             "Module::CPANfile" : "0.9025",
             "perl" : "5.008005"
          }

--- a/cpanfile
+++ b/cpanfile
@@ -32,6 +32,7 @@ requires 'Dist::Zilla::Plugin::TestRelease';
 requires 'Dist::Zilla::Plugin::UploadToCPAN';
 requires 'Dist::Zilla::Plugin::VersionFromModule';
 requires 'Dist::Zilla::Role::PluginBundle::Config::Slicer';
+requires 'Dist::Zilla::Role::PluginBundle::PluginRemover';
 requires 'Dist::Zilla::PluginBundle::Git';
 
 on test => sub {

--- a/lib/Dist/Zilla/PluginBundle/Milla.pm
+++ b/lib/Dist/Zilla/PluginBundle/Milla.pm
@@ -2,6 +2,7 @@ package Dist::Zilla::PluginBundle::Milla;
 use Dist::Milla;
 use Moose;
 with 'Dist::Zilla::Role::PluginBundle::Easy',
+     'Dist::Zilla::Role::PluginBundle::PluginRemover',
      'Dist::Zilla::Role::PluginBundle::Config::Slicer';
 
 use namespace::autoclean;


### PR DESCRIPTION
[`PluginRemover`](https://metacpan.org/pod/Dist::Zilla::Role::PluginBundle::PluginRemover) is a role that makes easy to disable some plugins from the set provided by Milla. Much cleaner than using [[`@Filter`](https://metacpan.org/pod/Dist::Zilla::PluginBundle::Filter)].
