### PR TITLE
switch from [ContributorsFromGit] to [Git::Contributors]

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Dist::Milla
 
 {{$NEXT}}
+        - switched from [ContributorsFromGit] to [Git::Contributors]
 
 v1.0.11  2015-01-18 11:15:10 PST
         - Minor documentation updates

--- a/cpanfile
+++ b/cpanfile
@@ -5,11 +5,11 @@ requires 'Module::CPANfile', 0.9025;
 
 requires 'Dist::Zilla::Plugin::CheckChangesHasContent';
 requires 'Dist::Zilla::Plugin::ConfirmRelease';
-requires 'Dist::Zilla::Plugin::ContributorsFromGit';
 requires 'Dist::Zilla::Plugin::CopyFilesFromBuild';
 requires 'Dist::Zilla::Plugin::CopyFilesFromRelease';
 requires 'Dist::Zilla::Plugin::ExecDir';
 requires 'Dist::Zilla::Plugin::ExtraTests';
+requires 'Dist::Zilla::Plugin::Git::Contributors';
 requires 'Dist::Zilla::Plugin::Git::Init', '2.012'; # commit = 0
 requires 'Dist::Zilla::Plugin::Git::GatherDir';
 requires 'Dist::Zilla::Plugin::GithubMeta';

--- a/lib/Dist/Zilla/PluginBundle/Milla.pm
+++ b/lib/Dist/Zilla/PluginBundle/Milla.pm
@@ -69,7 +69,7 @@ sub configure {
         [ 'Milla::MetaGeneratedBy' ],
 
         # x_contributors for MetaCPAN
-        [ 'ContributorsFromGit' ],
+        [ 'Git::Contributors' ],
 
         # add Milla itself as a develop dependency
         [ 'Prereqs', { -phase => 'develop', 'Dist::Milla' => Dist::Milla->VERSION } ],


### PR DESCRIPTION
It has fewer dependencies (for #24), and does not have test failure issues.

cc @dolmen 