### PR TITLE
add support of custom profile provider

### DIFF
--- a/lib/Dist/Milla/App.pm
+++ b/lib/Dist/Milla/App.pm
@@ -8,18 +8,28 @@ sub _default_command_base { 'Dist::Zilla::App::Command' }
 sub prepare_command {
     my $self = shift;
 
-    my($cmd, $opt, @args) = $self->SUPER::prepare_command(@_);
+    my($cmd, $opt, @args) = $self->SUPER::prepare_command(
+        $self->_check_default_profile_provider(@_)
+    );
 
     if ($cmd->isa("Dist::Zilla::App::Command::install")) {
         $opt->{install_command} ||= 'cpanm .';
     } elsif ($cmd->isa("Dist::Zilla::App::Command::release")) {
         $ENV{DZIL_CONFIRMRELEASE_DEFAULT} = 1
           unless defined $ENV{DZIL_CONFIRMRELEASE_DEFAULT};
-    } elsif ($cmd->isa("Dist::Zilla::App::Command::new")) {
-        $opt->{provider} = 'Milla';
-    }
+    } 
 
     return $cmd, $opt, @args;
+}
+
+sub _check_default_profile_provider {
+    my ($self, @opts) = @_;
+ 
+    if ($opts[0] eq 'new' && !grep(/^\-P|\-\-provider$/, @opts)) {
+        splice(@opts, 1, 0, '-P', 'Milla');
+    }
+    
+    return @opts;
 }
 
 1;

--- a/t/custom_provider.t
+++ b/t/custom_provider.t
@@ -1,0 +1,22 @@
+use strict;
+use Test::More;
+use Dist::Milla::App;
+
+#
+my $app = Dist::Milla::App->new;
+my ($cmd, $opt, @args) = $app->prepare_command('new');
+
+cmp_ok($opt->{provider}, 'eq', 'Milla', 'Default profile provider is still Milla');
+
+#
+my $expected = 'Default';
+my ($cmd, $opt, @args) = $app->prepare_command('new', '-P', $expected);
+
+cmp_ok($opt->{provider}, 'eq', $expected, 'Profile provider can be customized with short option -P');
+
+#
+my ($cmd, $opt, @args) = $app->prepare_command('new', '--provider', $expected);
+
+cmp_ok($opt->{provider}, 'eq', $expected, 'Profile provider can be customized with long option --provider');
+
+done_testing;


### PR DESCRIPTION
it enables the --provider | -P option and allows to use a different profile than the one provided by Milla
Milla is still the default profile provider

Signed-off-by:Eric Villard <evi@cpan.org>