### PR TITLE
Use ReadmeAnyFromPod for README in build directory

### DIFF
--- a/lib/Dist/Zilla/PluginBundle/Milla.pm
+++ b/lib/Dist/Zilla/PluginBundle/Milla.pm
@@ -78,7 +78,7 @@ sub configure {
         [ 'PodSyntaxTests' ],
         [ 'MetaYAML' ],
         [ 'License' ],
-        [ 'ReadmeFromPod', { readme => 'README' } ],
+        [ 'ReadmeAnyFromPod', 'ReadmeAnyFromPod/ReadmeTextInBuild' ],
         [ 'ExtraTests' ],
         [ 'ExecDir', { dir => 'script' } ],
         [ 'ShareDir' ],


### PR DESCRIPTION
[ReadmeFromPod](https://github.com/fayland/dist-zilla-plugin-readmefrompod) takes the POD text from the main ".pm" file even when a ".pod" file alternative exists (upstream issue already created at https://github.com/fayland/dist-zilla-plugin-readmefrompod/pull/6). [ReadmeAnyFromPod](https://github.com/gitpan/Dist-Zilla-Plugin-ReadmeAnyFromPod) does not suffer from this problem, and it is already used in Milla to generate the Markdown file in the root directory (so it's nothing new).

This proposal changes `ReadmeFromPod` to `ReadmeAnyFromPod,` with the right plugin name `ReadmeAnyFromPod/ReadmeTextInBuild` that creates a `README` file inside the build directory.