### PR TITLE
Bundle configuration for dirty files

### DIFF
--- a/lib/Dist/Zilla/PluginBundle/Milla.pm
+++ b/lib/Dist/Zilla/PluginBundle/Milla.pm
@@ -31,7 +31,10 @@ sub configure {
                     $self->installer);
     }
 
-    my @dirty_files = ('dist.ini', 'Changes', 'META.json', 'README.md', $self->build_file);
+    my $dirty_config = $self->config_slice(qw( add_files_in allow_dirty allow_dirty_match ));
+    my @dirty_files = ('dist.ini', 'Changes', 'META.json', 'README.md', $self->build_file, @{$dirty_config->{allow_dirty} || []});
+    my @dirty_matches = @{$dirty_config->{allow_dirty_match} || []};
+    my @additional_paths = @{$dirty_config->{add_files_in} || []};
     my @exclude_release = ('README.md');
 
     $self->add_plugins(
@@ -51,7 +54,10 @@ sub configure {
         # after ReversionOnRelease for munge_files, before Git::Commit for after_release
         [ 'NextRelease', { format => '%v  %{yyyy-MM-dd HH:mm:ss VVV}d' } ],
 
-        [ 'Git::Check', { allow_dirty => \@dirty_files } ],
+        [ 'Git::Check', {
+            allow_dirty => \@dirty_files,
+            (@dirty_matches ? (allow_dirty_match => \@dirty_matches) : ()),
+        } ],
 
         # Make Github center and front
         [ 'GithubMeta', { issues => 1 } ],
@@ -94,13 +100,16 @@ sub configure {
         [ 'Git::Commit', {
             commit_msg => '%v',
             allow_dirty => \@dirty_files,
-            allow_dirty_match => '\.pm$', # .pm files copied back from Release
+            allow_dirty_match => [@dirty_matches, '\.pm$'], # .pm files copied back from Release
+            (@additional_paths ? (add_files_in => \@additional_paths) : ()),
         } ],
         [ 'Git::Tag', { tag_format => '%v', tag_message => '' } ],
         [ 'Git::Push', { remotes_must_exist => 0 } ],
 
     );
 }
+
+sub mvp_multivalue_args { qw( add_files_in allow_dirty allow_dirty_match ) }
 
 __PACKAGE__->meta->make_immutable;
 1;
@@ -117,6 +126,11 @@ Dist::Zilla::PluginBundle::Milla - Dist::Zilla plugin defaults for Milla
   name = Dist-Name
   [@Milla]
   installer = MakeMaker
+  allow_dirty = some/autoupdated/file
+  allow_dirty = some/autoupdated/otherfile
+  allow_dirty_match = ^auto/gen-
+  add_files_in = some/auto/directory
+
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION
I have a distribution that automatically generates a simil-fatpacked file and I keep that file in the distribution and repository too, so that I can easily point to its copy here on GitHub.

I'm using CopyFilesFromRelease for getting the generated file from the build to the root, but it does not get automatically committed in Git which is annoying. I figured that the solution might be adding support for allow_dirty and siblings in Milla so here's a proposal, in the hope you might find it useful.

This patch adds support for adding custom files for Git check/commit phases. It adds support for the following:
- `add_files_in` - same meaning as in Git::Commit
- `allow_dirty` - same meaning as in Git::Check and Git::Commit
- `allow_dirty_match` - same meaning as in Git::Check and Git::Commit